### PR TITLE
include stdlib and unistd explicitly

### DIFF
--- a/CVE-2021-3156/callback.c
+++ b/CVE-2021-3156/callback.c
@@ -8,6 +8,8 @@
 
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 int main(void) {
     puts("[+] callback executed!");


### PR DESCRIPTION
I included both explicitly as my compiler gave me some errors implicitly declaring getuid, execve and exit