### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CVE-2020-28018/exim-4.92/src/child.c
+++ b/CVE-2020-28018/exim-4.92/src/child.c
@@ -63,7 +63,7 @@ Arguments:
                    CEE_RETURN_ARGV is specified, it is updated to give the
                    number of slots used
   minimal        TRUE if only minimal argv is required
-  acount         number of additional arguments
+  account         number of additional arguments
   ...            further values to add to argv
 
 Returns:         if CEE_RETURN_ARGV is given, returns a pointer to argv;
@@ -72,7 +72,7 @@ Returns:         if CEE_RETURN_ARGV is given, returns a pointer to argv;
 
 uschar **
 child_exec_exim(int exec_type, BOOL kill_v, int *pcount, BOOL minimal,
-  int acount, ...)
+  int account, ...)
 {
 int first_special = -1;
 int n = 0;
@@ -83,7 +83,7 @@ uschar **argv;
 if (tls_requiretls) extra++;
 #endif
 
-argv = store_get((extra + acount + MAX_CLMACROS + 18) * sizeof(char *));
+argv = store_get((extra + account + MAX_CLMACROS + 18) * sizeof(char *));
 
 /* In all case, the list starts out with the path, any macros, and a changed
 config file. */
@@ -137,12 +137,12 @@ if (tls_requiretls_copy & REQUIRETLS_MSG)
 /* Now add in any others that are in the call. Remember which they were,
 for more helpful diagnosis on failure. */
 
-if (acount > 0)
+if (account > 0)
   {
   va_list ap;
-  va_start(ap, acount);
+  va_start(ap, account);
   first_special = n;
-  while (acount-- > 0)
+  while (account-- > 0)
     argv[n++] = va_arg(ap, uschar *);
   va_end(ap);
   }

--- a/CVE-2020-28018/exim-4.92/src/host.c
+++ b/CVE-2020-28018/exim-4.92/src/host.c
@@ -2546,7 +2546,7 @@ Returns:                HOST_FIND_FAILED  Failed to find the host or domain;
                                           if there was a syntax error,
                                           host_find_failed_syntax is set.
                         HOST_FIND_AGAIN   Could not resolve at this time
-			HOST_FIND_SECURITY dnsssec required but not acheived
+			HOST_FIND_SECURITY dnssec required but not acheived
                         HOST_FOUND        Host found
                         HOST_FOUND_LOCAL  The lowest MX record points to this
                                           machine, if MX records were found, or

--- a/CVE-2020-28018/exim-4.92/src/malware.c
+++ b/CVE-2020-28018/exim-4.92/src/malware.c
@@ -1574,7 +1574,7 @@ badseek:  err = errno;
 	   * on both connections (as one host could resolve to multiple ips) */
 	  for (;;)
 	    {
-	    /*XXX we trust that the cmd_str is ideempotent */
+	    /*XXX we trust that the cmd_str is idempotent */
 	    if ((malware_daemon_ctx.sock = m_tcpsocket(cd->hostspec, cd->tcp_port,
 				    &connhost, &errstr, &cmd_str)) >= 0)
 	      {

--- a/CVE-2020-9273/proftpd-1.3.7rc2/contrib/mod_tls.c
+++ b/CVE-2020-9273/proftpd-1.3.7rc2/contrib/mod_tls.c
@@ -6231,7 +6231,7 @@ static int tls_init_ctx(void) {
     timeout = 15840;
 
 #else
-    /* If we are not supporting reneogtiations because the OpenSSL version
+    /* If we are not supporting renegotiations because the OpenSSL version
      * is too old, then set the default cache lifetime to 30 minutes.
      */
     timeout = 1800;

--- a/CVE-2020-9273/proftpd-1.3.7rc2/src/str.c
+++ b/CVE-2020-9273/proftpd-1.3.7rc2/src/str.c
@@ -237,7 +237,7 @@ char *sstrcat(char *dst, const char *src, size_t n) {
     return NULL;
   }
 
-  /* Edge case short ciruit; strlcat(3) doesn't do what I think it should
+  /* Edge case short circuit; strlcat(3) doesn't do what I think it should
    * do for this particular case.
    */
   if (n > 1) {


### PR DESCRIPTION
There are small typos in:
- CVE-2020-28018/exim-4.92/src/child.c
- CVE-2020-28018/exim-4.92/src/host.c
- CVE-2020-28018/exim-4.92/src/malware.c
- CVE-2020-9273/proftpd-1.3.7rc2/contrib/mod_tls.c
- CVE-2020-9273/proftpd-1.3.7rc2/src/str.c

Fixes:
- Should read `renegotiations` rather than `reneogtiations`.
- Should read `idempotent` rather than `ideempotent`.
- Should read `dnssec` rather than `dnsssec`.
- Should read `circuit` rather than `ciruit`.
- Should read `account` rather than `acount`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md